### PR TITLE
fix/ include the git lfs steps to install the wrapper for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@
 `$ react-native link bluedot-react-native`
 
 ### For iOS
-1. Install Pods
+1. Install `git-lfs` 
+2. Install Pods
 
 ```
 $ cd ios
+$ brew install git-lfs
+$ git lfs install 
 $ pod install
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bluedot-react-native",
   "title": "React Native Bluedot Point SDK",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bluedot Point SDK React Native SDK; integrates the Android and iOS Point SDK libraries",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updated the steps on how to install the wrapper for iOS:
* Added the `git lfs` step