### PR TITLE
Ni/fix send event null crash

### DIFF
--- a/android/src/main/java/io/bluedot/AppGeoTriggerReceiver.java
+++ b/android/src/main/java/io/bluedot/AppGeoTriggerReceiver.java
@@ -9,6 +9,7 @@ import au.com.bluedot.point.net.engine.ZoneEntryEvent;
 import au.com.bluedot.point.net.engine.ZoneExitEvent;
 import au.com.bluedot.point.net.engine.ZoneInfo;
 import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -96,9 +97,24 @@ public class AppGeoTriggerReceiver extends GeoTriggeringEventReceiver {
         ReactApplication reactApplication = (ReactApplication) context.getApplicationContext();
         ReactContext reactContext = reactApplication.getReactNativeHost().getReactInstanceManager()
                 .getCurrentReactContext();
-        reactContext
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(eventName, params);
+        ReactInstanceManager reactInstanceManager =
+                reactApplication.getReactNativeHost().getReactInstanceManager();
+
+        if (reactContext != null) {
+            reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(eventName, params);
+        } else {
+            reactInstanceManager.addReactInstanceEventListener(
+                    new ReactInstanceManager.ReactInstanceEventListener() {
+                        @Override
+                        public void onReactContextInitialized(ReactContext context) {
+                            context.getJSModule(
+                                    DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                    .emit(eventName, params);
+                            reactInstanceManager.removeReactInstanceEventListener(this);
+                        }
+                    });
+        }
     }
 
     @Override

--- a/android/src/main/java/io/bluedot/AppTempoReceiver.java
+++ b/android/src/main/java/io/bluedot/AppTempoReceiver.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 import au.com.bluedot.point.net.engine.BDError;
 import au.com.bluedot.point.net.engine.TempoTrackingReceiver;
 import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -36,8 +37,23 @@ public class AppTempoReceiver extends TempoTrackingReceiver {
         ReactApplication reactApplication = (ReactApplication) context.getApplicationContext();
         ReactContext reactContext = reactApplication.getReactNativeHost().getReactInstanceManager()
                 .getCurrentReactContext();
-        reactContext
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(eventName, params);
+        ReactInstanceManager reactInstanceManager =
+                reactApplication.getReactNativeHost().getReactInstanceManager();
+
+        if (reactContext != null) {
+            reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(eventName, params);
+        } else {
+            reactInstanceManager.addReactInstanceEventListener(
+                    new ReactInstanceManager.ReactInstanceEventListener() {
+                        @Override
+                        public void onReactContextInitialized(ReactContext context) {
+                            context.getJSModule(
+                                    DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                    .emit(eventName, params);
+                            reactInstanceManager.removeReactInstanceEventListener(this);
+                        }
+                    });
+        }
     }
 }

--- a/android/src/main/java/io/bluedot/BluedotErrorReceiver.java
+++ b/android/src/main/java/io/bluedot/BluedotErrorReceiver.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import au.com.bluedot.point.net.engine.BDError;
 import au.com.bluedot.point.net.engine.BluedotServiceReceiver;
 import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -42,8 +43,23 @@ public class BluedotErrorReceiver extends BluedotServiceReceiver {
         ReactApplication reactApplication = (ReactApplication) context.getApplicationContext();
         ReactContext reactContext = reactApplication.getReactNativeHost().getReactInstanceManager()
                 .getCurrentReactContext();
-        reactContext
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(eventName, params);
+        ReactInstanceManager reactInstanceManager =
+                reactApplication.getReactNativeHost().getReactInstanceManager();
+
+        if (reactContext != null) {
+            reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(eventName, params);
+        } else {
+            reactInstanceManager.addReactInstanceEventListener(
+                    new ReactInstanceManager.ReactInstanceEventListener() {
+                        @Override
+                        public void onReactContextInitialized(ReactContext context) {
+                            context.getJSModule(
+                                    DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                    .emit(eventName, params);
+                            reactInstanceManager.removeReactInstanceEventListener(this);
+                        }
+                    });
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bluedot-react-native",
   "title": "React Native Bluedot Point SDK",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Bluedot Point SDK React Native SDK; integrates the Android and iOS Point SDK libraries",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Can be tested on Minimal App with local changes to the bluedot plugin
Steps:
1. Initialize SDK
2. Provide Always Location permission.
3. Start BG mode Geo-triger.
4. swipe kill the app from the recent menu.
5. No crash should occur on the next rule download or Zone checkin