### PR TITLE
Support react-native 0.67.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bluedot-react-native",
   "title": "React Native Bluedot Point SDK",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Bluedot Point SDK React Native SDK; integrates the Android and iOS Point SDK libraries",
   "main": "index.js",
   "scripts": {
@@ -28,10 +28,10 @@
   "readmeFilename": "README.md",
   "peerDependencies": {
     "react": "^17.0.2",
-    "react-native": "<0.64.x"
+    "react-native": "<=0.67.x"
   },
   "devDependencies": {
     "react": "^17.0.2",
-    "react-native": "<0.64.x"
+    "react-native": "0.67.0"
   }
 }


### PR DESCRIPTION
- Updated react-native dependency to support 0.67.x
- Updated plugin version from 2.1.1 to 2.1.2

To test: Use the [React Native Minimal Integration App](https://github.com/Bluedot-Innovation/Bluedot-React-Native-Minimal-Integration) and link to the new plugin version 2.1.2 in `package.json -> dependencies`:
`"bluedot-react-native": "Bluedot-Innovation/Bluedot-React-Native-Plugin#dn/update-rn-67"`