### PR TITLE
Initial version of Push Notification support on iOS

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,3 @@
 # Bluedot React Native Plugin release notes
 
-- Integrated with Bluedot Android SDK v17.3.0 and iOS SDK 17.1.0
+- Integrated with Bluedot Android SDK v18.0.0 and iOS SDK 18.0.0

--- a/bluedot-react-native-pushnotifications/PushNotifications.js
+++ b/bluedot-react-native-pushnotifications/PushNotifications.js
@@ -1,6 +1,20 @@
 import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
 
-const pushEventEmitter = new NativeEventEmitter(NativeModules.BluedotPushNotificationsSDK);
+const androidPushEventEmitter =
+    Platform.OS === 'android' && NativeModules.BluedotPushNotificationsSDK
+        ? new NativeEventEmitter(NativeModules.BluedotPushNotificationsSDK)
+        : null;
+
+const iOSPushEventEmitter =
+    Platform.OS === 'ios' && NativeModules.BluedotPointSDK
+        ? new NativeEventEmitter(NativeModules.BluedotPointSDK)
+        : null;
+
+const getActiveEmitter = () => {
+    if (Platform.OS === 'android') return androidPushEventEmitter;
+    if (Platform.OS === 'ios') return iOSPushEventEmitter;
+    return null;
+};
 
 class PushNotifications {
 
@@ -9,6 +23,7 @@ class PushNotifications {
     PUSH_NOTIFICATION_CLICKED  = "pushNotificationClicked";
 
     /**
+     * Android only
      * Forward a new FCM token to the Bluedot push module.
      * Call this from your @react-native-firebase/messaging onTokenRefresh handler.
      *
@@ -20,6 +35,7 @@ class PushNotifications {
     }
 
     /**
+     * Android only
      * Forward an incoming FCM message to the Bluedot push module.
      * Call this from your @react-native-firebase/messaging onMessage and
      * setBackgroundMessageHandler callbacks.
@@ -36,23 +52,24 @@ class PushNotifications {
      *
      * Payload delivered to the callback contains:
      *   title        {string}              Notification title
-     *   body         {string}              Notification body
-     *   pushVersion  {string}              Push schema version
+     *   body         {string}              Notification body // Android only
+     *   pushVersion  {string}              Push schema version // Android only
      *   campaignId   {string}              Campaign UUID
      *   zoneId       {string}              Zone UUID
      *   notificationId {string}            Notification UUID
-     *   data         {object}              Custom key-value pairs from the payload
+     *   data         {object}              Custom key-value pairs from the payload // Android only
      *
      * @param {string}   eventName  One of the PUSH_NOTIFICATION_* constants above
      * @param {function} callback   Invoked with the push data payload
      * @returns {EmitterSubscription}  Call .remove() to unsubscribe
      */
-    on = (eventName, callback) => {
-        if (Platform.OS !== 'android') {
-            console.warn('BluedotPushNotifications: push notifications are only supported on Android.');
+     on = (eventName, callback) => {
+        const emitter = getActiveEmitter();
+        if (!emitter) {
+            console.warn('Native push emitter is not available on this platform.');
             return { remove: () => {} };
         }
-        return pushEventEmitter.addListener(eventName, callback);
+        return emitter.addListener(eventName, callback);
     }
 
     /**
@@ -61,8 +78,10 @@ class PushNotifications {
      * @param {string} eventName
      */
     removeAllListeners = (eventName) => {
-        pushEventEmitter.removeAllListeners(eventName);
-    }
+        const emitter = getActiveEmitter();
+        if (!emitter) return;
+        emitter.removeAllListeners(eventName);
+   }
 }
 
 export default new PushNotifications();

--- a/bluedot-react-native-pushnotifications/package.json
+++ b/bluedot-react-native-pushnotifications/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bluedot-react-native-pushnotifications",
   "title": "React Native Bluedot Push Notifications SDK",
-  "version": "4.0.0",
+  "version": "1.0.0",
   "description": "Bluedot Push Notifications React Native module; integrates the Android Push Notifications SDK library",
   "main": "index.js",
   "scripts": {

--- a/ios/BluedotPointSDK.m
+++ b/ios/BluedotPointSDK.m
@@ -20,6 +20,36 @@ RCT_EXPORT_MODULE()
         _dateFormatter = [ NSDateFormatter new ];
         [ _dateFormatter setDateFormat: @"dd-MMM-yyyy HH:mm" ];
     }
+
+        __weak typeof(self) weakSelf = self;
+    [BDLocationManager instance].pushNotifications.onNotificationReceived = ^(PushPayload *payload) {
+        if (!weakSelf) { return; }
+        
+        NSDictionary *notificationEventMap;
+        @try {
+            notificationEventMap = [weakSelf notificationEventMapFromPayload:payload];
+        } @catch (NSException *exception) {
+
+        } @finally {
+            [weakSelf sendEventWithName:@"pushNotificationReceived"
+                                    body:notificationEventMap];
+        }
+    };
+    
+    [BDLocationManager instance].pushNotifications.onNotificationClicked = ^(PushPayload *payload) {
+        if (!weakSelf) { return; }
+        
+        NSDictionary *notificationEventMap;
+        @try {
+            notificationEventMap = [weakSelf notificationEventMapFromPayload:payload];
+        } @catch (NSException *exception) {
+
+        } @finally {
+            [weakSelf sendEventWithName:@"pushNotificationClicked"
+                                    body:notificationEventMap];
+        }
+    };
+
     return self;
 }
 
@@ -228,125 +258,6 @@ RCT_EXPORT_METHOD(backgroundLocationAccessForWhileUsing: (BOOL) enable)
     BDLocationManager.instance.backgroundLocationAccessForWhileUsing = enable;
 }
 
-// Brain AI
-
-#define BRAIN_EVENT_TEXT_RESPONSE       @"brainEventTextResponse"
-#define BRAIN_EVENT_CONTEXT_RESPONSE    @"brainEventContextResponse"
-#define BRAIN_EVENT_ERROR               @"brainEventError"
-#define BRAIN_EVENT_ERROR_CODE          @"brainEventErrorCode"
-#define BRAIN_EVENT_RESPONSE_ID         @"brainEventResponseID"
-
-#define BRAIN_ERROR_CHAT_NOT_FOUND      @"Chat not found"
-#define BRAIN_ERROR_CREATE_CHAT         @"Failed to create chat"
-#define BRAIN_ERROR_SUBMIT_FEEDBACK     @"Failed to submit feedback"
-
-RCT_REMAP_METHOD(iOSCreateNewChat,
-                 isNewChatResolved:(RCTPromiseResolveBlock)resolve
-                 isNewChatRejected:(RCTPromiseRejectBlock)reject)
-{
-    RCTLogInfo(@"rzlv iOSCreateNewChat");
-    Chat *chat = [[BDLocationManager.instance brainAI] createNewChat];
-
-    if (chat == nil) {
-        reject(BRAIN_ERROR_CREATE_CHAT, @"Chat is null", nil);
-    } else {
-        RCTLogInfo(@"rzlv iOSCreateNewChat.success: %@", chat.sessionID);
-        resolve(chat.sessionID);
-    }
-}
-
-RCT_EXPORT_METHOD(iOSCloseChatWithSessionID:(NSString *)sessionId)
-{
-    RCTLogInfo(@"rzlv iOSCloseChatWithSessionID: %@", sessionId);
-    [[BDLocationManager.instance brainAI] closeChatWithSessionID:sessionId];
-}
-
-RCT_REMAP_METHOD(iOSGetChatSessionIds,
-                 isGetChatResolved:(RCTPromiseResolveBlock)resolve
-                 isGetChatRejected:(RCTPromiseRejectBlock)reject)
-{
-}
-
-- (NSDictionary *)toWritableMap:(ChatContext *)context {
-    NSMutableDictionary *map = [NSMutableDictionary dictionary];
-    map[@"title"] = context.title;
-    map[@"price"] = context.price;
-    map[@"description"] = context.description;
-    map[@"merchant_id"] = context.merchantID;
-    map[@"category_id"] = context.categoryID;
-    map[@"product_id"] = context.productID;
-    
-    if (context.imageLinks.count > 0) {
-        NSMutableArray *imageArray = [NSMutableArray array];
-        for (NSURL *item in context.imageLinks) {
-            [imageArray addObject:item.absoluteString];
-        }
-        map[@"image_links"] = imageArray;
-    }
-    return map;
-}
-
-RCT_EXPORT_METHOD(iOSSendMessage:(NSString *)sessionId message:(NSString *)message)
-{
-    RCTLogInfo(@"rzlv iOSSendMessage: %@: %@", sessionId, message);
-    Chat *chat = [[BDLocationManager.instance brainAI] getChatWithSessionID:sessionId];
-
-    if (chat == nil) {
-        NSDictionary *map = @{BRAIN_EVENT_ERROR: BRAIN_ERROR_CHAT_NOT_FOUND};
-        [self sendEventWithName:[NSString stringWithFormat:@"%@%@", BRAIN_EVENT_ERROR, sessionId] body:map];
-    }
-
-    [chat sendMessage:message onUpdate:^(StreamingResponseDto *res) {
-        if (res.streamType == 1) { // CONTEXT
-            RCTLogInfo(@"rzlv CONTEXT: %lu", res.contexts.count);
-            if (res.contexts.count > 0) {
-                NSMutableArray *array = [NSMutableArray array];
-                
-                for (id context in res.contexts) {
-                    [array addObject:[self toWritableMap:context]];
-                }
-                NSMutableDictionary *map = [NSMutableDictionary dictionary];
-                map[BRAIN_EVENT_CONTEXT_RESPONSE] = array;
-                map[BRAIN_EVENT_RESPONSE_ID] = res.responseID;
-                [self sendEventWithName:[NSString stringWithFormat:@"%@%@", BRAIN_EVENT_CONTEXT_RESPONSE, sessionId] body:map];
-            }
-        }
-
-        if (res.streamType == 2) { // RESPONSE_TEXT
-            RCTLogInfo(@"rzlv RESPONSE_TEXT: %@", res.response);
-            NSDictionary *map = @{BRAIN_EVENT_TEXT_RESPONSE: res.response};
-            [self sendEventWithName:[NSString stringWithFormat:@"%@%@", BRAIN_EVENT_TEXT_RESPONSE, sessionId] body:map];
-        }
-
-        if (res.streamType == 3) { // RESPONSE_IDENTIFIER
-            RCTLogInfo(@"rzlv RESPONSE_IDENTIFIER: %@", res.responseID);
-            NSDictionary *map = @{BRAIN_EVENT_RESPONSE_ID: res.responseID};
-            [self sendEventWithName:[NSString stringWithFormat:@"%@%@", BRAIN_EVENT_RESPONSE_ID, sessionId] body:map];
-        }
-    } onCompletion:^{
-        RCTLogInfo(@"rzlv iOSSendMessage Completed");
-    } onError:^(NSError *error) {
-        RCTLogInfo(@"rzlv iOSSendMessage Error: %@", error ? error.localizedDescription : @"No data");
-    }];
-}
-
-RCT_EXPORT_METHOD(iOSSubmitFeedback:(NSString *)sessionId responseId:(NSString *)responseId liked:(BOOL)liked)
-{
-    RCTLogInfo(@"rzlv iOSSubmitFeedback: %@: %@: %d", sessionId, responseId, liked);
-    Chat *chat = [[BDLocationManager.instance brainAI] getChatWithSessionID:sessionId];
-    Reaction feedback = liked ? ReactionLiked : ReactionDisliked;
-    
-    if (chat == nil) {
-        NSDictionary *map = @{BRAIN_EVENT_ERROR: BRAIN_ERROR_CHAT_NOT_FOUND};
-        [self sendEventWithName:[NSString stringWithFormat:@"%@%@", BRAIN_EVENT_ERROR, sessionId] body:map];
-    } else {
-        [chat submitFeedbackWithResponseID:responseId reaction:feedback completion:^(BOOL liked, NSError *error) {
-            NSDictionary *map = @{BRAIN_EVENT_ERROR: BRAIN_ERROR_SUBMIT_FEEDBACK};
-            [self sendEventWithName:[NSString stringWithFormat:@"%@%@", BRAIN_EVENT_ERROR, sessionId] body:map];
-        }];
-    }
-}
-
 /*
  ANDROID METHODS
  
@@ -379,7 +290,9 @@ RCT_EXPORT_METHOD(androidStartTempoTracking) {
         @"tempoTrackingStoppedWithError",
         @"lowPowerModeDidChange",
         @"locationAuthorizationDidChange",
-        @"accuracyAuthorizationDidChange"
+        @"accuracyAuthorizationDidChange",
+        @"pushNotificationReceived",
+        @"pushNotificationClicked"
     ];
 }
 
@@ -535,6 +448,24 @@ RCT_EXPORT_METHOD(androidStartTempoTracking) {
     [dict setObject:@(point.longitude) forKey:@"longitude"];
     
     return dict;
+}
+
+- (NSDictionary *)notificationEventMapFromPayload:(PushPayload *)payload {
+    Class adapterClass = NSClassFromString(@"BluedotPushAdapter");
+    SEL adapterSelector = NSSelectorFromString(@"notificationEventMapFromPayload:");
+
+    if (adapterClass != Nil && [adapterClass respondsToSelector:adapterSelector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        id eventMap = [adapterClass performSelector:adapterSelector withObject:payload];
+#pragma clang diagnostic pop
+
+        if ([eventMap isKindOfClass:[NSDictionary class]]) {
+            return eventMap;
+        }
+    }
+
+    return @{};
 }
 
 @end

--- a/ios/BluedotPointSDK.xcodeproj/project.pbxproj
+++ b/ios/BluedotPointSDK.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3046C7872A41314500B1078D /* BDPointSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3046C7862A41314500B1078D /* BDPointSDK.xcframework */; };
 		B3E7B58A1CC2AC0600A0062D /* BluedotPointSDK.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* BluedotPointSDK.m */; };
+		E16EAFAF2F9B0EF400D0C66B /* BluedotPushAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16EAFAE2F9B0EF400D0C66B /* BluedotPushAdapter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -151,6 +152,7 @@
 		78F37D4F238F86FC005517BB /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* BluedotPointSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BluedotPointSDK.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* BluedotPointSDK.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BluedotPointSDK.m; sourceTree = "<group>"; };
+		E16EAFAE2F9B0EF400D0C66B /* BluedotPushAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluedotPushAdapter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +188,7 @@
 			children = (
 				B3E7B5881CC2AC0600A0062D /* BluedotPointSDK.h */,
 				B3E7B5891CC2AC0600A0062D /* BluedotPointSDK.m */,
+				E16EAFAE2F9B0EF400D0C66B /* BluedotPushAdapter.swift */,
 				134814211AA4EA7D00B7C361 /* Products */,
 				78F37D4C238F867B005517BB /* Framework */,
 				3046C7852A41314500B1078D /* Frameworks */,
@@ -255,6 +258,7 @@
 				TargetAttributes = {
 					58B511DA1A9E6C8500147676 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 2630;
 					};
 				};
 			};
@@ -403,6 +407,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* BluedotPointSDK.m in Sources */,
+				E16EAFAF2F9B0EF400D0C66B /* BluedotPushAdapter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -513,6 +518,7 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -523,17 +529,20 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = BluedotPointSDK;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -544,11 +553,12 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = BluedotPointSDK;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/ios/BluedotPushAdapter.swift
+++ b/ios/BluedotPushAdapter.swift
@@ -1,0 +1,25 @@
+//
+//  BluedotPushAdapter.swift
+//
+//  Created by Natalia Klymenko on 26/2/2026.
+//  Copyright © 2026 Bluedot Innovation. All rights reserved.
+//
+
+import Foundation
+import BDPointSDK
+
+@objc(BluedotPushAdapter)
+public final class BluedotPushAdapter: NSObject {
+
+    @objc(notificationEventMapFromPayload:)
+    public class func notificationEventMap(from payload: PushPayload) -> NSDictionary {
+        return [
+            "title": payload.title,
+            "body": "",
+            "campaignId": payload.campaignId,
+            "zoneId": payload.zoneId,
+            "notificationId": payload.notificationId
+        ] as NSDictionary
+    }
+}
+

--- a/ios/Cartfile.private
+++ b/ios/Cartfile.private
@@ -1,1 +1,1 @@
-github "Bluedot-Innovation/PointSDK-iOS" "17.1.0"
+github "Bluedot-Innovation/PointSDK-iOS" "18.0.0"

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Bluedot-Innovation/PointSDK-iOS" "17.1.0"
+github "Bluedot-Innovation/PointSDK-iOS" "18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bluedot-react-native",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bluedot-react-native",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "ISC",
       "devDependencies": {
         "@react-native-community/cli": "latest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bluedot-react-native",
   "title": "React Native Bluedot Point SDK",
-  "version": "4.0.0",
+  "version": "3.5.0",
   "description": "Bluedot Point SDK React Native SDK; integrates the Android and iOS Point SDK libraries",
   "main": "index.js",
   "files": [

--- a/react-native-plugin.podspec
+++ b/react-native-plugin.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
     :type => 'Copyright',
     :text => <<-LICENSE
     Point SDK
-    Created by Bluedot Innovation in 2025.
-    Copyright © 2025 Bluedot Innovation. All rights reserved.
+    Created by Bluedot Innovation in 2026.
+    Copyright © 2026 Bluedot Innovation. All rights reserved.
     By downloading or using the Bluedot Point SDK for iOS, You agree to the Bluedot Terms and Conditions
     https://bluedot.io/agreements/#terms and Privacy Policy https://bluedot.io/agreements/#privacy
     and Billing Policy https://bluedot.io/agreements/#billing
@@ -30,6 +30,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m,swift}"
   s.requires_arc  = true
 
-  s.dependency "BluedotPointSDK", "17.1.0"
+  s.dependency "BluedotPointSDK", "18.0.0"
   s.dependency "React"
 end


### PR DESCRIPTION
Notes/Discuss:
1. notificationEventMap & "Subscribe to a push notification event." Payload that differs on iOS and Android
2. the push notification module on iOS appears to be split between core and push notifications module as it discussed
3. All testing and Bitrise build will be possible after public release of iOS BluedotPointSDK 18.0.0
4. Releasing two modules to the npm registry adds complexity. It requires coordinating versioning, publishing, and dependency alignment between modules.
We would also need to extend our Bitrise pipelines to build, test, and publish both modules consistently, which increases setup and maintenance overhead.