### PR TITLE
Ak/18.0.0 cleanup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,28 +12,10 @@ import groovy.json.JsonSlurper
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
+apply from: file('../versions.gradle')
+
 def DEFAULT_COMPILE_SDK_VERSION = 36
 def DEFAULT_MIN_SDK_VERSION = 26
-
-// ---------------------------------------------------------------------------
-// Downstream / CI build switch
-//
-// To build against a private GitLab Maven artifact instead of JitPack, simply
-// provide a gitlabPipelineId. When set, the private registry is added and the
-// versioned artifact is used. When absent, JitPack is used as normal.
-//
-// Pass as Gradle properties on the command line or via gradle.properties:
-//
-//   -PgitlabMavenToken=<your-GitLab-personal-or-CI-token>
-//   -PgitlabPipelineId=<artifact-version>   (e.g. the pipeline ID / semver)
-//
-// Example:
-//   ./gradlew assembleRelease \
-//     -PgitlabMavenToken=$CI_JOB_TOKEN \
-//     -PgitlabPipelineId=$CI_PIPELINE_ID
-// ---------------------------------------------------------------------------
-def gitlabMavenToken   = project.findProperty('gitlabMavenToken')   ?: ''
-def gitlabPipelineId   = project.findProperty('gitlabPipelineId')   ?: ''
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -63,18 +45,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        if (gitlabPipelineId) {
-            maven {
-                url 'https://gitlab.com/api/v4/projects/14682665/packages/maven'
-                credentials(HttpHeaderCredentials) {
-                    name  'Private-Token'
-                    value gitlabMavenToken
-                }
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-            }
-        }
         maven { url 'https://jitpack.io' }
     }
 }
@@ -122,15 +92,8 @@ repositories {
     mavenCentral()
 }
 
-def sdkDependency
-if (gitlabPipelineId) {
-    sdkDependency = "au.com.bluedot:pointsdk:${gitlabPipelineId}"
-} else {
-    sdkDependency = 'com.gitlab.bluedotio.android:point_sdk_android:18.0.0'
-}
-
 dependencies {
-    implementation sdkDependency
+    implementation "com.gitlab.bluedotio.android:point_sdk_android:${pointSdkVersion}"
     implementation 'com.facebook.react:react-android:0.77.0'
     implementation 'androidx.core:core-ktx:1.15.0'
 }

--- a/android/src/main/java/io/bluedot/BluedotPointSdkModule.java
+++ b/android/src/main/java/io/bluedot/BluedotPointSdkModule.java
@@ -81,7 +81,7 @@ public class BluedotPointSdkModule extends ReactContextBaseJavaModule implements
                 onSucessCallback.invoke(text);
             }
         };
-        serviceManager.initialize(projectId, resultListener);
+        serviceManager.initialize(projectId, "https://globalconfig.dev-bluedot.com/", resultListener);
     }
 
     @ReactMethod

--- a/android/src/main/java/io/bluedot/BluedotPointSdkModule.java
+++ b/android/src/main/java/io/bluedot/BluedotPointSdkModule.java
@@ -81,7 +81,7 @@ public class BluedotPointSdkModule extends ReactContextBaseJavaModule implements
                 onSucessCallback.invoke(text);
             }
         };
-        serviceManager.initialize(projectId, "https://globalconfig.dev-bluedot.com/", resultListener);
+        serviceManager.initialize(projectId, resultListener);
     }
 
     @ReactMethod

--- a/bluedot-react-native-pushnotifications/android/build.gradle
+++ b/bluedot-react-native-pushnotifications/android/build.gradle
@@ -1,27 +1,9 @@
 import groovy.json.JsonSlurper
 
+apply from: file('../../versions.gradle')
+
 def DEFAULT_COMPILE_SDK_VERSION = 36
 def DEFAULT_MIN_SDK_VERSION = 29
-
-// ---------------------------------------------------------------------------
-// Downstream / CI build switch
-//
-// To build against a private GitLab Maven artifact instead of JitPack, simply
-// provide a gitlabPipelineId. When set, the private registry is added and the
-// versioned artifact is used. When absent, JitPack is used as normal.
-//
-// Pass as Gradle properties on the command line or via gradle.properties:
-//
-//   -PgitlabMavenToken=<your-GitLab-personal-or-CI-token>
-//   -PgitlabPipelineId=<artifact-version>   (e.g. the pipeline ID / semver)
-//
-// Example:
-//   ./gradlew assembleRelease \
-//     -PgitlabMavenToken=$CI_JOB_TOKEN \
-//     -PgitlabPipelineId=$CI_PIPELINE_ID
-// ---------------------------------------------------------------------------
-def gitlabMavenToken   = project.findProperty('gitlabMavenToken')   ?: ''
-def gitlabPipelineId   = project.findProperty('gitlabPipelineId')   ?: ''
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -47,18 +29,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     google()
-    if (gitlabPipelineId) {
-        maven {
-            url 'https://gitlab.com/api/v4/projects/14682665/packages/maven'
-            credentials(HttpHeaderCredentials) {
-                name  'Private-Token'
-                value gitlabMavenToken
-            }
-            authentication {
-                header(HttpHeaderAuthentication)
-            }
-        }
-    }
     maven { url 'https://jitpack.io' }
 }
 
@@ -97,32 +67,11 @@ android {
     }
 }
 
-def sdkDependency
-def pointSdkDependency
-if (gitlabPipelineId) {
-    sdkDependency      = "au.com.bluedot:pushnotifications:${gitlabPipelineId}"
-    pointSdkDependency = "au.com.bluedot:pointsdk:${gitlabPipelineId}"
-} else {
-    sdkDependency      = 'com.gitlab.bluedotio.android:pushnotifications:18.0.0'
-    pointSdkDependency = 'com.gitlab.bluedotio.android:point_sdk_android:18.0.0'
-}
-
-// ---------------------------------------------------------------------------
-// Firebase BOM version
-//
-// The consumer app is responsible for applying the google-services plugin and
-// placing google-services.json in their own app module. This library only
-// needs the firebase-messaging artifact on the compile classpath; it does NOT
-// need (or want) the google-services Gradle plugin.
-//
-// Override the BOM version from your app's build.gradle / gradle.properties:
-//   ext.firebaseBomVersion = '34.0.0'
-// ---------------------------------------------------------------------------
 def firebaseBomVersion = safeExtGet('firebaseBomVersion', '34.12.0')
 
 dependencies {
-    implementation sdkDependency
-    implementation pointSdkDependency
+    implementation "com.gitlab.bluedotio.android:point_sdk_push:${pointSdkVersion}"
+    implementation "com.gitlab.bluedotio.android:point_sdk_android:${pointSdkVersion}"
     implementation 'com.facebook.react:react-android:0.77.0'
     implementation 'androidx.core:core-ktx:1.15.0'
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,0 +1,5 @@
+// Single source of truth for shared dependency versions across all modules.
+// Both android/ and bluedot-react-native-pushnotifications/android/ apply this file.
+ext {
+    pointSdkVersion = '18.0.0'
+}


### PR DESCRIPTION
Clean extra code to load private sdk artifacts.
Use single source of truth for the sdk version.